### PR TITLE
Provision a Basic System User

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# terraform-aws-iam-basic-user
-Terraform Module to Provision a Basic IAM User Suitable for CI/CD Systems (E.g. TravisCI, CircleCI)
+# terraform-aws-iam-system-user
+
+Terraform Module to Provion a basic IAM system user suitable for CI/CD Systems (E.g. TravisCI, CircleCI) or systems which are *external* to AWS that cannot leverage [AWS IAM Instance Profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html).
+
+We do not recommend creating IAM users this way for any other purpose.
+
+## Usage
+
+```
+module "circleci" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=master"
+  namespace  = "cp"
+  stage      = "circleci"
+  name       = "assets"
+}
+```
+
+## Variables
+
+|  Name                          |  Default                          |  Description                                                                                                                    | Required |
+|:-------------------------------|:---------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------|:--------:|
+| `namespace`                    | ``                                | Namespace (e.g. `cp` or `cloudposse`)                                                                                           | No       |
+| `stage`                        | ``                                | Stage (e.g. `prod`, `dev`, `staging`)                                                                                           | No       |
+| `name`                         | ``                                | Name  (e.g. `bastion` or `db`)                                                                                                  | Yes      |
+| `attributes`                   | `[]`                              | Additional attributes (e.g. `policy` or `role`)                                                                                 | No       |
+| `force_destroy`                | `false`                           | Destroy even if it has non-Terraform-managed IAM access keys, login profile or MFA devices.                                     | No       |
+| `path`                         | `/`                               | Path in which to create the user                                                                                                | No       |
+
+## Outputs
+
+| Name                        | Description                                                                     |
+|:----------------------------|:--------------------------------------------------------------------------------|
+| `user_name`                 | Normalized IAM user name                                                        |
+| `user_arn`                  | The ARN assigned by AWS for this user                                           |
+| `user_unique_id`            | The unique ID assigned by AWS                                                   |
+| `access_key_id`             | The access key ID                                                               |
+| `secret_access_key`         | The secret access key. This will be written to the state file in plain-text     |
+
+## License
+
+Apache 2 License. See [`LICENSE`](LICENSE) for full details.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ module "circleci" {
 | `stage`                        | ``                                | Stage (e.g. `prod`, `dev`, `staging`)                                                                                           | No       |
 | `name`                         | ``                                | Name  (e.g. `bastion` or `db`)                                                                                                  | Yes      |
 | `attributes`                   | `[]`                              | Additional attributes (e.g. `policy` or `role`)                                                                                 | No       |
+| `tags`                         | `{}`                              | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                                                                              | No       |
+| `delimiter`                    | `-`                               | Delimiter to be used between `name`, `namespace`, `stage`, `arguments`, etc.                                                    | No       |
 | `force_destroy`                | `false`                           | Destroy even if it has non-Terraform-managed IAM access keys, login profile or MFA devices.                                     | No       |
 | `path`                         | `/`                               | Path in which to create the user                                                                                                | No       |
 

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ module "label" {
   name       = "${var.name}"
   attributes = "${var.attributes}"
   delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
 }
 
 # Defines a user that should be able to write to you test bucket

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,23 @@
+module "label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
+}
+
+# Defines a user that should be able to write to you test bucket
+resource "aws_iam_user" "default" {
+  name          = "${module.label.id}"
+  path          = "${var.path}"
+  force_destroy = "${var.force_destroy}"
+}
+
+# Generate API credentials
+resource "aws_iam_access_key" "default" {
+  user = "${aws_iam_user.default.name}"
+}
+
+

--- a/main.tf
+++ b/main.tf
@@ -3,9 +3,8 @@ module "label" {
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
   attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  delimiter  = "${var.delimiter}"
 }
 
 # Defines a user that should be able to write to you test bucket

--- a/main.tf
+++ b/main.tf
@@ -19,5 +19,3 @@ resource "aws_iam_user" "default" {
 resource "aws_iam_access_key" "default" {
   user = "${aws_iam_user.default.name}"
 }
-
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,13 @@
-output "name" {
+output "user_name" {
   value = "${aws_iam_user.default.name}"
 }
 
-output "unique_id" {
-  value = "${aws_iam_user.default.unique_id}"
+output "user_arn" {
+  value = "${aws_iam_user.default.arn}"
 }
 
-output "arn" {
-  value = "${aws_iam_user.default.arn}"
+output "user_unique_id" {
+  value = "${aws_iam_user.default.unique_id}"
 }
 
 output "access_key_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,19 @@
+output "name" {
+  value = "${aws_iam_user.default.name}"
+}
+
+output "unique_id" {
+  value = "${aws_iam_user.default.unique_id}"
+}
+
+output "arn" {
+  value = "${aws_iam_user.default.arn}"
+}
+
+output "access_key_id" {
+  value = "${aws_iam_access_key.default.id}"
+}
+
+output "secret_access_key" {
+  value = "${aws_iam_access_key.default.id}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,5 +15,5 @@ output "access_key_id" {
 }
 
 output "secret_access_key" {
-  value = "${aws_iam_access_key.default.id}"
+  value = "${aws_iam_access_key.default.secret}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,10 +22,10 @@ variable "delimiter" {
 
 variable "force_destroy" {
   description = "Destroy even if it has non-Terraform-managed IAM access keys, login profile or MFA devices."
-  default = "false"
+  default     = "false"
 }
 
 variable "path" {
   description = "Path in which to create the user"
-  default = "/"
+  default     = "/"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,31 @@
+variable "name" {}
+
+variable "namespace" {
+  default = ""
+}
+
+variable "stage" {
+  default = ""
+}
+
+variable "attributes" {
+  default = []
+}
+
+variable "tags" {
+  default = {}
+}
+
+variable "delimiter" {
+  default = "-"
+}
+
+variable "force_destroy" {
+  description = "Destroy even if it has non-Terraform-managed IAM access keys, login profile or MFA devices."
+  default = "false"
+}
+
+variable "path" {
+  description = "Path in which to create the user"
+  default = "/"
+}


### PR DESCRIPTION
## what
* Provision a basic IAM user
* Provision a basic IAM Access Key/Secret Access Key

## why
* For CI/CD systems or other systems which are incompatible with IAM Instance Profiles 