### PR TITLE
Use splat syntax for outputs to access resources with `count`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # Module directory
 .terraform/
+.idea
+*.iml
+

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Cloud Posse, LLC
+   Copyright 2017-2018 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # terraform-aws-iam-system-user [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-iam-system-user.svg)](https://travis-ci.org/cloudposse/terraform-aws-iam-system-user)
 
-Terraform Module to Provion a basic IAM system user suitable for CI/CD Systems (E.g. TravisCI, CircleCI) or systems which are *external* to AWS that cannot leverage [AWS IAM Instance Profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html).
+Terraform Module to provision a basic IAM system user suitable for CI/CD Systems
+(_e.g._ TravisCI, CircleCI) or systems which are *external* to AWS that cannot leverage [AWS IAM Instance Profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html).
 
 We do not recommend creating IAM users this way for any other purpose.
+
 
 ## Usage
 
 ### Simple usage
 
-```terraform
+```hcl
 module "circleci" {
   source     = "git::https://github.com/cloudposse/terraform-aws-iam-system-user.git?ref=master"
   namespace  = "cp"
@@ -19,7 +21,7 @@ module "circleci" {
 
 ### Full usage
 
-```terraform
+```hcl
 data "aws_iam_policy_document" "fluentd_user_policy" {
   statement {
     actions = [
@@ -52,6 +54,7 @@ module "fluentd_user" {
 }
 ```
 
+
 ## Variables
 
 | Name            | Default | Description                                                                                 | Required |
@@ -67,6 +70,7 @@ module "fluentd_user" {
 | `enabled`       | `true`  | Flag for creation user                                                                      |    No    |
 | `policy`        |   ``    | User policy in `json` format                                                                |    No    |
 
+
 ## Outputs
 
 | Name                | Description                                                                 |
@@ -76,6 +80,7 @@ module "fluentd_user" {
 | `user_unique_id`    | The unique ID assigned by AWS                                               |
 | `access_key_id`     | The access key ID                                                           |
 | `secret_access_key` | The secret access key. This will be written to the state file in plain-text |
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ module "fluentd_user" {
 
 | Name            | Default | Description                                                                                 | Required |
 |:----------------|:-------:|:--------------------------------------------------------------------------------------------|:--------:|
-| `namespace`     |   ``    | Namespace (e.g. `cp` or `cloudposse`)                                                       |    No    |
-| `stage`         |   ``    | Stage (e.g. `prod`, `dev`, `staging`)                                                       |    No    |
+| `namespace`     |   ``    | Namespace (e.g. `cp` or `cloudposse`)                                                       |   Yes    |
+| `stage`         |   ``    | Stage (e.g. `prod`, `dev`, `staging`)                                                       |   Yes    |
 | `name`          |   ``    | Name  (e.g. `bastion` or `db`)                                                              |   Yes    |
 | `attributes`    |  `[]`   | Additional attributes (e.g. `policy` or `role`)                                             |    No    |
 | `tags`          |  `{}`   | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                                          |    No    |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ module "fluentd_user" {
 | `delimiter`     |   `-`   | Delimiter to be used between `name`, `namespace`, `stage`, `arguments`, etc.                |    No    |
 | `force_destroy` | `false` | Destroy even if it has non-Terraform-managed IAM access keys, login profile or MFA devices. |    No    |
 | `path`          |   `/`   | Path in which to create the user                                                            |    No    |
-| `enabled`       | `true`  | Flag for creation user                                                                      |    No    |
+| `enabled`       | `true`  | Set to `false` to prevent the module from creating any resources                            |    No    |
 | `policy`        |   ``    | User policy in `json` format                                                                |    No    |
 
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,19 @@
 output "user_name" {
-  value = "${aws_iam_user.default.name}"
+  value = "${join("", aws_iam_user.default.*.name)}"
 }
 
 output "user_arn" {
-  value = "${aws_iam_user.default.arn}"
+  value = "${join("", aws_iam_user.default.*.arn)}"
 }
 
 output "user_unique_id" {
-  value = "${aws_iam_user.default.unique_id}"
+  value = "${join("", aws_iam_user.default.*.unique_id)}"
 }
 
 output "access_key_id" {
-  value = "${aws_iam_access_key.default.id}"
+  value = "${join("", aws_iam_access_key.default.*.id)}"
 }
 
 output "secret_access_key" {
-  value = "${aws_iam_access_key.default.secret}"
+  value = "${join("", aws_iam_access_key.default.*.secret)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,10 +9,12 @@ variable "stage" {
 }
 
 variable "attributes" {
+  type    = "list"
   default = []
 }
 
 variable "tags" {
+  type    = "map"
   default = {}
 }
 
@@ -31,7 +33,7 @@ variable "path" {
 }
 
 variable "enabled" {
-  description = "Flag for creation user. Set to false if necessary skip run of module"
+  description = "Set to false to prevent the module from creating any resources"
   default     = "true"
 }
 


### PR DESCRIPTION
## what
* Use splat syntax for outputs to access resources with `count`

## why
* To prevent Terraform warnings:

```
Warning: output "user_name": must use splat syntax to access aws_iam_user.default attribute "name", because it has "count" set; use aws_iam_user.default.*.name to obtain a list of the attributes across all instances
Warning: output "user_arn": must use splat syntax to access aws_iam_user.default attribute "arn", because it has "count" set; use aws_iam_user.default.*.arn to obtain a list of the attributes across all instances
Warning: output "user_unique_id": must use splat syntax to access aws_iam_user.default attribute "unique_id", because it has "count" set; use aws_iam_user.default.*.unique_id to obtain a list of the attributes across all instances
Warning: output "access_key_id": must use splat syntax to access aws_iam_access_key.default attribute "id", because it has "count" set; use aws_iam_access_key.default.*.id to obtain a list of the attributes across all instances
Warning: output "secret_access_key": must use splat syntax to access aws_iam_access_key.default attribute "secret", because it has "count" set; use aws_iam_access_key.default.*.secret to obtain a list of the attributes across all instances
```

## Issues
* https://github.com/cloudposse/terraform-aws-iam-system-user/issues/4