### PR TITLE
terraform-null-label version bump

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.4"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"


### PR DESCRIPTION
## What
* terraform-null-label version bump

## Why
* Problems with output for disabled module.
if module is disabled getting this:
```
* module.s3_bucket.module.s3_user.module.s3_user.module.label.output.attributes: Resource 'null_resource.default' not found for variable 'null_resource.default.triggers.attributes'
* module.s3_bucket.module.s3_user.module.s3_user.module.label.output.tags: Resource 'null_resource.default' not found for variable 'null_resource.default.triggers.id'
* module.s3_bucket.module.s3_user.module.s3_user.module.label.output.namespace: Resource 'null_resource.default' not found for variable 'null_resource.default.triggers.namespace'
* module.s3_bucket.module.s3_user.module.s3_user.module.label.output.stage: Resource 'null_resource.default' not found for variable 'null_resource.default.triggers.stage'
* module.s3_bucket.module.s3_user.module.s3_user.module.label.output.name: Resource 'null_resource.default' not found for variable 'null_resource.default.triggers.name'
* module.s3_bucket.module.s3_user.module.s3_user.module.label.output.id: Resource 'null_resource.default' not found for variable 'null_resource.default.triggers.id'
```
This is because output doesn't respect `enabled` flag in old release:
```
output "id" {
  value = "${null_resource.default.triggers.id}"
}
```