### PR TITLE
Mark the IAM user secret access key as sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,7 @@ output "access_key_id" {
 }
 
 output "secret_access_key" {
+  sensitive   = true
   value       = "${join("", aws_iam_access_key.default.*.secret)}"
   description = "The secret access key. This will be written to the state file in plain-text"
 }


### PR DESCRIPTION
We do not want this leaking out and being displayed on each Terraform
run. We should probably be writing these to SSM but this is at least a
stop gap since we have rolled out Atlantis so Terraform plan/apply get
run in the context of a PR.