### PR TITLE
Add tags to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
 
+## Discourse Forums
+
+Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
+
 ## Newsletter
 
 Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover. 
@@ -353,6 +357,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-iam-system-user&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-iam-system-user&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-iam-system-user&utm_content=newsletter
+  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-iam-system-user&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-iam-system-user&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-iam-system-user&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-iam-system-user&utm_content=we_love_open_source

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ resource "aws_iam_user" "default" {
   name          = module.label.id
   path          = var.path
   force_destroy = var.force_destroy
+  tags          = var.tags
 }
 
 # Generate API credentials


### PR DESCRIPTION
* This appeared to have been a simple omission.
* Documentation for tags is already up to date.

## what
* Tags are now passed along to the underlying `aws_iam_user` resource
* These tags will apply to the IAM user

## why
* The documentation claims tags will be set, and they were previously not.
* Tags are commonly used, both in general AWS and within CloudPosse's modules, so this is important for consistency.

## references
* I have not created a GitHib issue for this, although I certainly can if that conforms to process.

## Validation
I ran without this change and created a user -- no tags were shown in the Terraform plan output and no tags were shown in the AWS console. With this change Terraform plan showed the following:

```
  ~ resource "aws_iam_user" "default" {
        arn           = "arn:aws:iam::<redacted>"
        force_destroy = false
        id            = "my-user-id"
        name          = "my-user-name"
        path          = "/"
      ~ tags          = {
          + "my-tag" = "my-tag-va;ue"
        }
        unique_id     = "<redacted?"
    }
```

And as expected I can see the tags in the AWS console for my user. 