### PR TITLE
Allow policy attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,13 @@ Available targets:
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
 | force\_destroy | Destroy the user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices | `bool` | `false` | no |
+| inline\_policies | Inline policies to attach to our created user | `list(string)` | `[]` | no |
+| inline\_policies\_map | Inline policies to attach (descriptive key => policy) | `map(string)` | `{}` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | `string` | n/a | yes |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
 | path | Path in which to create the user | `string` | `"/"` | no |
+| policy\_arns | Policy ARNs to attach to our created user | `list(string)` | `[]` | no |
+| policy\_arns\_map | Policy ARNs to attach (descriptive key => arn) | `map(string)` | `{}` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')`) | `map(string)` | `{}` | no |
 
@@ -280,22 +284,24 @@ Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 See [LICENSE](LICENSE) for full details.
 
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+```text
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-      https://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -331,8 +331,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Konstantin B][comeanother_avatar]][comeanother_homepage]<br/>[Konstantin B][comeanother_homepage] |
-|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Konstantin B][comeanother_avatar]][comeanother_homepage]<br/>[Konstantin B][comeanother_homepage] | [![Chris Weyl][rsrchboy_avatar]][rsrchboy_homepage]<br/>[Chris Weyl][rsrchboy_homepage] |
+|---|---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
@@ -344,6 +344,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [SweetOps_avatar]: https://img.cloudposse.com/150x150/https://github.com/SweetOps.png
   [comeanother_homepage]: https://github.com/comeanother
   [comeanother_avatar]: https://img.cloudposse.com/150x150/https://github.com/comeanother.png
+  [rsrchboy_homepage]: https://github.com/rsrchboy
+  [rsrchboy_avatar]: https://img.cloudposse.com/150x150/https://github.com/rsrchboy.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -132,3 +132,5 @@ contributors:
     github: "SweetOps"
   - name: "Konstantin B"
     github: "comeanother"
+  - name: "Chris Weyl"
+    github: "rsrchboy"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -22,9 +22,13 @@
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
 | force\_destroy | Destroy the user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices | `bool` | `false` | no |
+| inline\_policies | Inline policies to attach to our created user | `list(string)` | `[]` | no |
+| inline\_policies\_map | Inline policies to attach (descriptive key => policy) | `map(string)` | `{}` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | `string` | n/a | yes |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
 | path | Path in which to create the user | `string` | `"/"` | no |
+| policy\_arns | Policy ARNs to attach to our created user | `list(string)` | `[]` | no |
+| policy\_arns\_map | Policy ARNs to attach (descriptive key => arn) | `map(string)` | `{}` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')`) | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ locals {
   )
   policy_arns_map = merge(
     var.policy_arns_map,
-    { for i in var.policy_arns : md5(i) => i },
+    { for i in var.policy_arns : i => i },
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -24,3 +24,35 @@ resource "aws_iam_access_key" "default" {
   count = var.enabled ? 1 : 0
   user  = aws_iam_user.default[0].name
 }
+
+# policies -- inline and otherwise
+
+locals {
+  inline_policies_map = merge(
+    var.inline_policies_map,
+    { for i in var.inline_policies : md5(i) => i },
+  )
+  policy_arns_map = merge(
+    var.policy_arns_map,
+    { for i in var.policy_arns : md5(i) => i },
+  )
+}
+
+resource "aws_iam_user_policy" "inline_policies" {
+  for_each = var.enabled ? local.inline_policies_map : {}
+  lifecycle {
+    create_before_destroy = true
+  }
+  name_prefix = module.label.id
+  user        = join("", aws_iam_user.default.*.name)
+  policy      = each.value
+}
+
+resource "aws_iam_user_policy_attachment" "policies" {
+  for_each = var.enabled ? local.policy_arns_map : {}
+  lifecycle {
+    create_before_destroy = true
+  }
+  user       = join("", aws_iam_user.default.*.name)
+  policy_arn = each.value
+}

--- a/variables.tf
+++ b/variables.tf
@@ -56,3 +56,27 @@ variable "enabled" {
   description = "Set to false to prevent the module from creating any resources"
   default     = true
 }
+
+variable "inline_policies" {
+    type        = list(string)
+    description = "Inline policies to attach to our created user"
+    default     = []
+}
+
+variable "inline_policies_map" {
+    type        = map(string)
+    description = "Inline policies to attach (descriptive key => policy)"
+    default     = {}
+}
+
+variable "policy_arns" {
+    type        = list(string)
+    description = "Policy ARNs to attach to our created user"
+    default     = []
+}
+
+variable "policy_arns_map" {
+    type        = map(string)
+    description = "Policy ARNs to attach (descriptive key => arn)"
+    default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -58,25 +58,25 @@ variable "enabled" {
 }
 
 variable "inline_policies" {
-    type        = list(string)
-    description = "Inline policies to attach to our created user"
-    default     = []
+  type        = list(string)
+  description = "Inline policies to attach to our created user"
+  default     = []
 }
 
 variable "inline_policies_map" {
-    type        = map(string)
-    description = "Inline policies to attach (descriptive key => policy)"
-    default     = {}
+  type        = map(string)
+  description = "Inline policies to attach (descriptive key => policy)"
+  default     = {}
 }
 
 variable "policy_arns" {
-    type        = list(string)
-    description = "Policy ARNs to attach to our created user"
-    default     = []
+  type        = list(string)
+  description = "Policy ARNs to attach to our created user"
+  default     = []
 }
 
 variable "policy_arns_map" {
-    type        = map(string)
-    description = "Policy ARNs to attach (descriptive key => arn)"
-    default     = {}
+  type        = map(string)
+  description = "Policy ARNs to attach (descriptive key => arn)"
+  default     = {}
 }


### PR DESCRIPTION
## what
* Consumers can now specify policy docs or ARNs to attach to the created user
* Map inputs are provided as an option so as to be better able to avoid the dreaded "cannot be computed" error

## why
* Often the first thing we do is attach policies to new system users; this allows that step to be handled by the module as well