### PR TITLE
`try()` to generate `output.ses_smtp_password_v4`

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -26,6 +26,6 @@ output "secret_access_key" {
 
 output "ses_smtp_password_v4" {
   sensitive   = true
-  value       = join("", aws_iam_access_key.default.*.ses_smtp_password_v4)
+  value       = try(join("", aws_iam_access_key.default.*.ses_smtp_password_v4), null)
   description = "The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm"
 }


### PR DESCRIPTION
In module upgrades, I'm seeing errors like this:

    Error: Invalid function argument

    on .terraform/modules/user/outputs.tf line 29, in output "ses_smtp_password_v4":
    29:   value       = join("", aws_iam_access_key.default.*.ses_smtp_password_v4)
        |----------------
        | aws_iam_access_key.default is tuple with 1 element

    Invalid value for "lists" parameter: element 0 is null; cannot concatenate
    null values.

This change wraps the `join()` with a `try(..., null)`, causing `null`
to be returned as a fallback on error.