### PR TITLE
Fix typo for inline_policies_map example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ module "fluentd_user" {
   }
 
   inline_policies_map = {
-    s3 = aws_iam_policy_document.s3_policy.json
+    s3 = data.aws_iam_policy_document.s3_policy.json
   }
 }
 

--- a/README.yaml
+++ b/README.yaml
@@ -89,7 +89,7 @@ examples: |-
     }
 
     inline_policies_map = {
-      s3 = aws_iam_policy_document.s3_policy.json
+      s3 = data.aws_iam_policy_document.s3_policy.json
     }
   }
 


### PR DESCRIPTION
## what
* Fix minor typo in README.

