### PR TITLE
Feature/bool enabled iam key creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Available targets:
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| create\_iam\_access\_key | Whether or not to create IAM access keys | `bool` | `true` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,6 +21,7 @@
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| create\_iam\_access\_key | Whether or not to create IAM access keys | `bool` | `true` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_iam_user" "default" {
 
 # Generate API credentials
 resource "aws_iam_access_key" "default" {
-  count = module.this.enabled ? 1 : 0
+  count = module.this.enabled && var.create_iam_access_key ? 1 : 0
   user  = join("", aws_iam_user.default.*.name)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,9 @@ variable "policy_arns_map" {
   description = "Policy ARNs to attach (descriptive key => arn)"
   default     = {}
 }
+
+variable "create_iam_access_key" {
+  type        = bool
+  description = "Whether to create IAM access keys or not"
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,6 @@ variable "policy_arns_map" {
 
 variable "create_iam_access_key" {
   type        = bool
-  description = "Whether to create IAM access keys or not"
+  description = "Whether or not to create IAM access keys"
   default     = true
 }


### PR DESCRIPTION
## what
* adds `create_iam_access_key` boolean variable to conditionally create `aws_iam_access_key`.
* defaults to `true` which aligns with current expected behavior 
## why
* We would prefer to not create access keys that are stored in terraform state 
## references
* https://github.com/cloudposse/terraform-aws-iam-system-user/issues/44

You guys and your modules rock! 
