### PR TITLE
Tolerate missing ses_smtp_password_v4 attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,21 @@ Available targets:
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_access_key](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_access_key) |
+| [aws_iam_user](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_user) |
+| [aws_iam_user_policy](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_user_policy) |
+| [aws_iam_user_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_user_policy_attachment) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -217,7 +232,6 @@ Available targets:
 | user\_arn | The ARN assigned by AWS for this user |
 | user\_name | Normalized IAM user name |
 | user\_unique\_id | The unique ID assigned by AWS |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,6 +12,21 @@
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_access_key](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_access_key) |
+| [aws_iam_user](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_user) |
+| [aws_iam_user_policy](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_user_policy) |
+| [aws_iam_user_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_user_policy_attachment) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -49,5 +64,4 @@
 | user\_arn | The ARN assigned by AWS for this user |
 | user\_name | Normalized IAM user name |
 | user\_unique\_id | The unique ID assigned by AWS |
-
 <!-- markdownlint-restore -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,6 +26,6 @@ output "secret_access_key" {
 
 output "ses_smtp_password_v4" {
   sensitive   = true
-  value       = join("", aws_iam_access_key.default.*.ses_smtp_password_v4)
+  value       = join("", compact(aws_iam_access_key.default.*.ses_smtp_password_v4))
   description = "The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm"
 }


### PR DESCRIPTION
## what
* Tolerate Terraform states where the `ses_smtp_password_v4` attribute is missing

## why
* In some scenarios, this attribute may be missing from the state. One example, taken from the official documentation, is: _"Resource attributes such as encrypted_secret, key_fingerprint, pgp_key, secret, and ses_smtp_password_v4 are not available for imported resources as this information cannot be read from the IAM API."_

## references
* closes #39
* Terraform iam_access_key [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key)

