### PR TITLE
Disable writing to store when create_iam_access_key is set to false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ module "store_write" {
   source  = "cloudposse/ssm-parameter-store/aws"
   version = "0.8.2"
 
-  count = module.this.enabled && var.ssm_enabled ? 1 : 0
+  count = module.this.enabled && var.ssm_enabled && var.create_iam_access_key ? 1 : 0
 
   parameter_write = [
     {


### PR DESCRIPTION
Setting the create_iam_access_key parameter to `false` throws an error when running  `terraform plan`.

## references
* Closes #55 

