### PR TITLE
add expiring iam_access_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,14 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
+| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.11.0 |
 
 ## Modules
 
@@ -194,6 +196,7 @@ Available targets:
 | [aws_iam_user.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy.inline_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_iam_user_policy_attachment.policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [awsutils_expiring_iam_access_key.default](https://registry.terraform.io/providers/cloudposse/awsutils/latest/docs/resources/expiring_iam_access_key) | resource |
 
 ## Inputs
 
@@ -208,6 +211,7 @@ Available targets:
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Destroy the user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices | `bool` | `false` | no |
+| <a name="input_iam_access_key_max_age"></a> [iam\_access\_key\_max\_age](#input\_iam\_access\_key\_max\_age) | Maximum age of IAM access key (seconds). Defaults to 30 days. Set to 0 to disable expiration. | `number` | `2592000` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_inline_policies"></a> [inline\_policies](#input\_inline\_policies) | Inline policies to attach to our created user | `list(string)` | `[]` | no |
 | <a name="input_inline_policies_map"></a> [inline\_policies\_map](#input\_inline\_policies\_map) | Inline policies to attach (descriptive key => policy) | `map(string)` | `{}` | no |
@@ -388,8 +392,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Konstantin B][comeanother_avatar]][comeanother_homepage]<br/>[Konstantin B][comeanother_homepage] | [![Chris Weyl][rsrchboy_avatar]][rsrchboy_homepage]<br/>[Chris Weyl][rsrchboy_homepage] |
-|---|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Konstantin B][comeanother_avatar]][comeanother_homepage]<br/>[Konstantin B][comeanother_homepage] | [![Chris Weyl][rsrchboy_avatar]][rsrchboy_homepage]<br/>[Chris Weyl][rsrchboy_homepage] | [![Matt Calhoun][mcalhoun_avatar]][mcalhoun_homepage]<br/>[Matt Calhoun][mcalhoun_homepage] |
+|---|---|---|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -404,6 +408,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [comeanother_avatar]: https://img.cloudposse.com/150x150/https://github.com/comeanother.png
   [rsrchboy_homepage]: https://github.com/rsrchboy
   [rsrchboy_avatar]: https://img.cloudposse.com/150x150/https://github.com/rsrchboy.png
+  [mcalhoun_homepage]: https://github.com/mcalhoun
+  [mcalhoun_avatar]: https://img.cloudposse.com/150x150/https://github.com/mcalhoun.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -172,14 +172,14 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
-| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.11.0 |
+| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.11 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
-| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.11.0 |
+| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.11 |
 
 ## Modules
 

--- a/README.yaml
+++ b/README.yaml
@@ -43,7 +43,9 @@ badges:
 
 related:
   - name: "terraform-aws-iam-s3-user"
-    description: "Terraform module to provision a basic IAM user with permissions to access S3 resources, e.g. to give the user read/write/delete access to the objects in an S3 bucket"
+    description:
+      "Terraform module to provision a basic IAM user with permissions to access S3 resources, e.g. to give the user
+      read/write/delete access to the objects in an S3 bucket"
     url: "https://github.com/cloudposse/terraform-aws-iam-s3-user"
   - name: "terraform-aws-iam-assumed-roles"
     description: "Terraform Module for Assumed Roles on AWS with IAM Groups Requiring MFA"
@@ -52,10 +54,15 @@ related:
     description: "Terraform module to provision an IAM role with configurable permissions to access SSM Parameter Store"
     url: "https://github.com/cloudposse/terraform-aws-ssm-iam-role"
   - name: "terraform-aws-iam-chamber-user"
-    description: "Terraform module to provision a basic IAM chamber user with access to SSM parameters and KMS key to decrypt secrets, suitable for CI/CD systems (e.g. TravisCI, CircleCI, CodeFresh) or systems which are external to AWS that cannot leverage AWS IAM Instance Profiles"
+    description:
+      "Terraform module to provision a basic IAM chamber user with access to SSM parameters and KMS key to decrypt
+      secrets, suitable for CI/CD systems (e.g. TravisCI, CircleCI, CodeFresh) or systems which are external to AWS that
+      cannot leverage AWS IAM Instance Profiles"
     url: "https://github.com/cloudposse/terraform-aws-iam-chamber-user"
   - name: "terraform-aws-lb-s3-bucket"
-    description: "Terraform module to provision an S3 bucket with built in IAM policy to allow AWS Load Balancers to ship access logs"
+    description:
+      "Terraform module to provision an S3 bucket with built in IAM policy to allow AWS Load Balancers to ship access
+      logs"
     url: "https://github.com/cloudposse/terraform-aws-lb-s3-bucket"
 
 # Short description of this project
@@ -136,3 +143,5 @@ contributors:
     github: "comeanother"
   - name: "Chris Weyl"
     github: "rsrchboy"
+  - name: "Matt Calhoun"
+    github: "mcalhoun"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,14 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
-| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.11.0 |
+| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.11 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
-| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.11.0 |
+| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.11 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,12 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
+| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.11.0 |
 
 ## Modules
 
@@ -27,6 +29,7 @@
 | [aws_iam_user.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy.inline_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_iam_user_policy_attachment.policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [awsutils_expiring_iam_access_key.default](https://registry.terraform.io/providers/cloudposse/awsutils/latest/docs/resources/expiring_iam_access_key) | resource |
 
 ## Inputs
 
@@ -41,6 +44,7 @@
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Destroy the user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices | `bool` | `false` | no |
+| <a name="input_iam_access_key_max_age"></a> [iam\_access\_key\_max\_age](#input\_iam\_access\_key\_max\_age) | Maximum age of IAM access key (seconds). Defaults to 30 days. Set to 0 to disable expiration. | `number` | `2592000` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_inline_policies"></a> [inline\_policies](#input\_inline\_policies) | Inline policies to attach to our created user | `list(string)` | `[]` | no |
 | <a name="input_inline_policies_map"></a> [inline\_policies\_map](#input\_inline\_policies\_map) | Inline policies to attach (descriptive key => policy) | `map(string)` | `{}` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,9 +2,9 @@ provider "aws" {
   region = var.region
 }
 
-# provider "awsutils" {
-#   region = var.region
-# }
+ provider "awsutils" {
+   region = var.region
+ }
 
 module "iam_system_user" {
   source = "../../"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,9 +2,9 @@ provider "aws" {
   region = var.region
 }
 
- provider "awsutils" {
-   region = var.region
- }
+provider "awsutils" {
+  region = var.region
+}
 
 module "iam_system_user" {
   source = "../../"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,6 +2,10 @@ provider "aws" {
   region = var.region
 }
 
+# provider "awsutils" {
+#   region = var.region
+# }
+
 module "iam_system_user" {
   source = "../../"
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     awsutils = {
       source  = "cloudposse/awsutils"
-      version = ">= 0.11.0"
+      version = ">= 0.11"
     }
     local = {
       source  = "hashicorp/local"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,14 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.14.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 2.0"
+    }
+    awsutils = {
+      source  = "cloudposse/awsutils"
+      version = ">= 0.11.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,18 +14,18 @@ output "user_unique_id" {
 }
 
 output "access_key_id" {
-  value       = join("", aws_iam_access_key.default.*.id)
+  value       = join("", local.access_key.*.id)
   description = "The access key ID"
 }
 
 output "secret_access_key" {
   sensitive   = true
-  value       = join("", aws_iam_access_key.default.*.secret)
+  value       = join("", local.access_key.*.secret)
   description = "The secret access key. This will be written to the state file in plain-text"
 }
 
 output "ses_smtp_password_v4" {
   sensitive   = true
-  value       = join("", compact(aws_iam_access_key.default.*.ses_smtp_password_v4))
+  value       = join("", compact(local.access_key.*.ses_smtp_password_v4))
   description = "The secret access key converted into an SES SMTP password by applying AWS's Sigv4 conversion algorithm"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,6 @@ variable "iam_access_key_max_age" {
     condition     = var.iam_access_key_max_age >= 0
     error_message = "The iam_access_key_max_age must be 0 (disabled) or greater."
   }
-
 }
 
 variable "ssm_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,18 @@ variable "create_iam_access_key" {
   default     = true
 }
 
+variable "iam_access_key_max_age" {
+  type        = number
+  description = "Maximum age of IAM access key (seconds). Defaults to 30 days. Set to 0 to disable expiration."
+  default     = 2592000
+
+  validation {
+    condition     = var.iam_access_key_max_age >= 0
+    error_message = "The iam_access_key_max_age must be 0 (disabled) or greater."
+  }
+
+}
+
 variable "ssm_enabled" {
   type        = bool
   description = "Whether or not to write the IAM access key and secret key to SSM Parameter Store"

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
+    awsutils = {
+      source  = "cloudposse/awsutils"
+      version = ">= 0.11.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     awsutils = {
       source  = "cloudposse/awsutils"
-      version = ">= 0.11.0"
+      version = ">= 0.11"
     }
   }
 }


### PR DESCRIPTION
## what

* By default, when the `create_iam_access_key` variable is `true`, create an IAM Access Key that will expire after 30 days.
* After the `iam_access_key_max_age` have elapsed, running `terraform plan` and `terraform apply` again will produce a new secret access key.

## why

* Security best practices dictate that you should rotate your password/credentials on a periodic basis

## references
* [awsutils_expiring_iam_access_key](https://registry.terraform.io/providers/cloudposse/awsutils/latest/docs/resources/expiring_iam_access_key)

