### PR TITLE
add ses smpt password to ssm, add ssm base path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,9 @@ Available targets:
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | Policy ARNs to attach to our created user | `list(string)` | `[]` | no |
 | <a name="input_policy_arns_map"></a> [policy\_arns\_map](#input\_policy\_arns\_map) | Policy ARNs to attach (descriptive key => arn) | `map(string)` | `{}` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| <a name="input_ssm_base_path"></a> [ssm\_base\_path](#input\_ssm\_base\_path) | The base path for SSM parameters | `string` | `"/system_user"` | no |
+| <a name="input_ssm_base_path"></a> [ssm\_base\_path](#input\_ssm\_base\_path) | The base path for SSM parameters | `string` | `"/system_user/"` | no |
 | <a name="input_ssm_enabled"></a> [ssm\_enabled](#input\_ssm\_enabled) | Whether or not to write the IAM access key and secret key to SSM Parameter Store | `bool` | `true` | no |
+| <a name="input_ssm_ses_smtp_password_enabled"></a> [ssm\_ses\_smtp\_password\_enabled](#input\_ssm\_ses\_smtp\_password\_enabled) | Whether or not to write the SES SMTP password to SSM Parameter Store | `bool` | `false` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -59,8 +59,9 @@
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | Policy ARNs to attach to our created user | `list(string)` | `[]` | no |
 | <a name="input_policy_arns_map"></a> [policy\_arns\_map](#input\_policy\_arns\_map) | Policy ARNs to attach (descriptive key => arn) | `map(string)` | `{}` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| <a name="input_ssm_base_path"></a> [ssm\_base\_path](#input\_ssm\_base\_path) | The base path for SSM parameters | `string` | `"/system_user"` | no |
+| <a name="input_ssm_base_path"></a> [ssm\_base\_path](#input\_ssm\_base\_path) | The base path for SSM parameters | `string` | `"/system_user/"` | no |
 | <a name="input_ssm_enabled"></a> [ssm\_enabled](#input\_ssm\_enabled) | Whether or not to write the IAM access key and secret key to SSM Parameter Store | `bool` | `true` | no |
+| <a name="input_ssm_ses_smtp_password_enabled"></a> [ssm\_ses\_smtp\_password\_enabled](#input\_ssm\_ses\_smtp\_password\_enabled) | Whether or not to write the SES SMTP password to SSM Parameter Store | `bool` | `false` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -68,18 +68,25 @@ module "store_write" {
 
   parameter_write = [
     {
-      name        = "/system_user/${local.username}/access_key_id"
+      name        = "${trimsuffix(var.ssm_base_path, "/")}/${local.username}/access_key_id"
       value       = join("", local.access_key.*.id)
       type        = "SecureString"
       overwrite   = true
       description = "The AWS_ACCESS_KEY_ID for the ${local.username} user."
     },
     {
-      name        = "/system_user/${local.username}/secret_access_key"
+      name        = "${trimsuffix(var.ssm_base_path, "/")}/${local.username}/secret_access_key"
       value       = join("", local.access_key.*.secret)
       type        = "SecureString"
       overwrite   = true
       description = "The AWS_SECRET_ACCESS_KEY for the ${local.username} user."
+    },
+    {
+      name        = "${trimsuffix(var.ssm_base_path, "/")}/${local.username}/ses_smtp_password_v4"
+      value       = join("", compact(local.access_key.*.ses_smtp_password_v4))
+      type        = "SecureString"
+      overwrite   = true
+      description = "The AWS_SECRET_ACCESS_KEY converted into an SES SMTP password for the ${local.username} user."
     }
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ module "store_write" {
 
   count = module.this.enabled && var.ssm_enabled && var.create_iam_access_key ? 1 : 0
 
-  parameter_write = [
+  parameter_write = concat([
     {
       name        = "${trimsuffix(var.ssm_base_path, "/")}/${local.username}/access_key_id"
       value       = join("", local.access_key.*.id)
@@ -80,15 +80,15 @@ module "store_write" {
       type        = "SecureString"
       overwrite   = true
       description = "The AWS_SECRET_ACCESS_KEY for the ${local.username} user."
-    },
+    }], var.ssm_ses_smtp_password_enabled ? [
     {
       name        = "${trimsuffix(var.ssm_base_path, "/")}/${local.username}/ses_smtp_password_v4"
       value       = join("", compact(local.access_key.*.ses_smtp_password_v4))
       type        = "SecureString"
       overwrite   = true
       description = "The AWS_SECRET_ACCESS_KEY converted into an SES SMTP password for the ${local.username} user."
-    }
-  ]
+    }] : []
+  )
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -63,8 +63,14 @@ variable "ssm_enabled" {
   default     = true
 }
 
+variable "ssm_ses_smtp_password_enabled" {
+  type        = bool
+  description = "Whether or not to write the SES SMTP password to SSM Parameter Store"
+  default     = false
+}
+
 variable "ssm_base_path" {
   type        = string
   description = "The base path for SSM parameters"
-  default     = "/system_user"
+  default     = "/system_user/"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -62,3 +62,9 @@ variable "ssm_enabled" {
   description = "Whether or not to write the IAM access key and secret key to SSM Parameter Store"
   default     = true
 }
+
+variable "ssm_base_path" {
+  type        = string
+  description = "The base path for SSM parameters"
+  default     = "/system_user"
+}


### PR DESCRIPTION
## what
* Add option to change the SSM base path under which credentials are stored
* Store ses_smtp_password_v4 in SSM

## why
* Even if the IAM users are global per account often times there is a need to separeate them per environment (dev, staging). By adding the `ssm_base_path` parameter we can have a better SSM hierarchy. Example: `/dev/system_user/tc-dev-s3` and `/staging/system_user/tc-staging-ses`
* Also having the `ses_smtp_password_v4` stored in SSM will allow better integration with CI systems when deploying applications (rather than having a script to generate the password or read the terraform state)

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* closes #60

