### PR TITLE
Fix `ssm_enabled = false` usage

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,7 +38,7 @@ output "secret_access_key" {
 
 output "ses_smtp_password_v4" {
   sensitive   = true
-  value       = local.ssm_enabled ? null : join("", aws_iam_access_key.default.*.ses_smtp_password_v4)
+  value       = local.ssm_enabled ? null : join("", compact(aws_iam_access_key.default.*.ses_smtp_password_v4))
   description = <<-EOT
     When `ssm_enabled` is false, this is the secret access key converted into an SES SMTP password
     by applying AWS's Sigv4 conversion algorithm. It will be written to the Terraform state file in plaintext.


### PR DESCRIPTION
```
│ Error: Invalid function argument
│ 
│   on .terraform/modules/service_codefresh_serverless/outputs.tf line 41, in output "ses_smtp_password_v4":
│   41:   value       = local.ssm_enabled ? null : join("", aws_iam_access_key.default.*.ses_smtp_password_v4)
│     ├────────────────
│     │ while calling join(separator, lists...)
│     │ aws_iam_access_key.default is tuple with 1 element
│ 
│ Invalid value for "lists" parameter: element 0 is null; cannot concatenate null values.
```


